### PR TITLE
Add rules for findOneBy and findOneByOrFail

### DIFF
--- a/enforce-equal.js
+++ b/enforce-equal.js
@@ -39,6 +39,30 @@ const rule = {
           });
         }
       },
+      CallExpression: node => {
+        if (node.callee.type === 'Identifier' && node.callee.name.startsWith('findOneBy')) {
+          const args = node.arguments;
+          // Step 2: Inspect the first argument to ensure it's an object literal
+          if (args.length > 0 && args[0].type === 'ObjectExpression') {
+            const properties = args[0].properties;
+            for (const property of properties) {
+              // Ensure property value is not wrapped in Equal()
+              // This is a simplification. You might need to handle more complex cases.
+              const key = property.key;
+              const value = property.value;
+              if ((value.type === 'CallExpression' && value.callee.name !== 'Equal') || (value.type === 'Identifier')) {
+                context.report({
+                  node: property.value,
+                  messageId: 'useTypeORMComparisonHelper',
+                  fix: key.type === 'Identifier'
+                    ? fixer => fixer.replaceText(property, `${key.name}: Equal(${value.type === 'Identifier' ? value.name : `${value.callee.name}()`})`)
+                    : undefined,
+                });
+              }
+            }
+          }
+        }
+      },
     };
   },
 };

--- a/enforce-equal.test.js
+++ b/enforce-equal.test.js
@@ -36,4 +36,47 @@ ruleTester.run(
   }
 );
 
+ruleTester.run(
+  "enforce-equal", // rule name
+  enforceEqualRule, // rule code
+  { // checks
+    // 'valid' checks cases that should pass
+    valid: [{
+      code: 'findOneBy({ id: Equal(someVariable) })',
+    },
+    {
+      code: "findOneBy({ someVariable: '123' })",
+    },
+    {
+      code: 'findOneByOrFail({ id: Equal(someVariable) })',
+    },
+    {
+      code: "findOneByOrFail({ someVariable: '123' })",
+    }],
+    // 'invalid' checks cases that should not pass
+    invalid: [
+      {
+        code: 'findOneBy({ someVariable: test })',
+        output: 'findOneBy({ someVariable: Equal(test) })',
+        errors: [{ messageId: 'useTypeORMComparisonHelper' }],
+      },
+      {
+        code: 'findOneBy({ someVariable: test() })',
+        output: 'findOneBy({ someVariable: Equal(test) })',
+        errors: [{ messageId: 'useTypeORMComparisonHelper' }],
+      },
+      {
+        code: 'findOneByOrFail({ someVariable: test })',
+        output: 'findOneByOrFail({ someVariable: Equal(test()) })',
+        errors: [{ messageId: 'useTypeORMComparisonHelper' }],
+      },
+      {
+        code: 'findOneByOrFail({ someVariable: test() })',
+        output: 'findOneByOrFail({ someVariable: Equal(test()) })',
+        errors: [{ messageId: 'useTypeORMComparisonHelper' }],
+      }
+    ],
+  }
+);
+
 console.log("All tests passed!");

--- a/eslint-plugin-nopillo.js
+++ b/eslint-plugin-nopillo.js
@@ -1,5 +1,9 @@
 // eslint-plugin-nopillo.js
 
 const enforceEqualRule = require("./enforce-equal");
-const plugin = { rules: { "enforce-equal": enforceEqualRule } };
+const plugin = {
+    rules: {
+        "enforce-equal": enforceEqualRule,
+    }
+};
 module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-nopillo",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "ESLint plugin for enforce-equal rule.",
   "main": "eslint-plugin-nopillo.js",
   "scripts": {


### PR DESCRIPTION
Handle Equal for the findOneBy and findOneByOrFail

for the future: handle the cases where the first argument is the entity type
as in ` await entityManager.findOneByOrFail(OtpKey, { id })`